### PR TITLE
chore: add /authors and /authors/:id routes

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -8,6 +8,6 @@
 
 <body>
   <div id="root"></div>
-<script type="text/javascript" src="main.js"></script></body>
+<script type="text/javascript" src="/main.js"></script></body>
 
 </html>

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Route, Switch, Redirect } from 'react-router-dom'
 import Home from './views/Home.jsx'
+import AuthorPage from './views/AuthorPage.jsx'
 
 const App = (props) => (
   <Switch>
-    <Route path='/authors/:id' render={() => 'author + id'} />
-    <Route path='/authors' render={() => 'author'} />
+    <Route path='/authors/:id' component={AuthorPage} />
+    <Route path='/authors' render={() => 'authors list'} />
     <Route path='/' exact component={Home} />
     <Redirect to='/' />
   </Switch>

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Route, Switch, Redirect } from 'react-router-dom';
+import Home from './views/Home.jsx'
+const app = (props) => {
+  let routes = (
+    <Switch>
+      <Route path="/authors/:id" render={() => 'author + id'} />
+			<Route path="/authors" render={() => 'author'} />
+      <Route path="/" exact component={Home} />
+      <Redirect to="/" />
+		</Switch>
+  )
+  return (
+    routes
+  )
+}
+
+export default app;

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,18 +1,14 @@
-import React from 'react';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import React from 'react'
+import { Route, Switch, Redirect } from 'react-router-dom'
 import Home from './views/Home.jsx'
-const app = (props) => {
-  let routes = (
-    <Switch>
-      <Route path="/authors/:id" render={() => 'author + id'} />
-			<Route path="/authors" render={() => 'author'} />
-      <Route path="/" exact component={Home} />
-      <Redirect to="/" />
-		</Switch>
-  )
-  return (
-    routes
-  )
-}
 
-export default app;
+const App = (props) => (
+  <Switch>
+    <Route path='/authors/:id' render={() => 'author + id'} />
+    <Route path='/authors' render={() => 'author'} />
+    <Route path='/' exact component={Home} />
+    <Redirect to='/' />
+  </Switch>
+)
+
+export default App

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'
 import { StoreContext } from 'redux-react-hook'
-import { BrowserRouter, Route } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import store from './store'
-import App from './app';
+import App from './app'
 
 ReactDOM.render(
   <BrowserRouter>

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -4,12 +4,12 @@ import './index.css'
 import { StoreContext } from 'redux-react-hook'
 import { BrowserRouter, Route } from 'react-router-dom'
 import store from './store'
-import Home from './views/Home.jsx'
+import App from './app';
 
 ReactDOM.render(
   <BrowserRouter>
     <StoreContext.Provider value={store}>
-      <Route component={Home} />
+      <App />
     </StoreContext.Provider>
   </BrowserRouter>,
   document.getElementById('root')

--- a/frontend/src/views/AuthorPage.jsx
+++ b/frontend/src/views/AuthorPage.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import SampleCard from '../components/SampleCard'
+
+// on merging replace mock data coresponding to your id with your AuthorAbout component
+
+function switchAuthors (id) {
+  const authors = {
+    1: <SampleCard />,
+    2: 'author2 component',
+    3: 'author3 component',
+    4: 'author4 component',
+    5: 'author5 component'
+  }
+  return authors[id] || 'not existing author'
+}
+
+export default function AuthorPage (props) {
+  return (
+    switchAuthors(props.match.params.id)
+  )
+}

--- a/src/app.js
+++ b/src/app.js
@@ -46,5 +46,12 @@ module.exports = function({ port }) {
     prefix: '/api/v1/authors'
   });
 
-  return app;
-};
+
+    app.register(require('./routes/catch-all/catch-all-api-404'), {
+      prefix: '/api'
+    });
+
+    app.register(require('./routes/catch-all/catch-all'));
+
+  return app
+}

--- a/src/app.js
+++ b/src/app.js
@@ -46,12 +46,11 @@ module.exports = function({ port }) {
     prefix: '/api/v1/authors'
   });
 
+  app.register(require('./routes/catch-all/catch-all-api-404'), {
+    prefix: '/api'
+  })
 
-    app.register(require('./routes/catch-all/catch-all-api-404'), {
-      prefix: '/api'
-    });
-
-    app.register(require('./routes/catch-all/catch-all'));
+  app.register(require('./routes/catch-all/catch-all'))
 
   return app
 }

--- a/src/routes/catch-all/catch-all-api-404.js
+++ b/src/routes/catch-all/catch-all-api-404.js
@@ -1,11 +1,11 @@
 const catchAllApi = function (fastify, options, done) {
   fastify.get('*', (request, reply) => {
-    reply.code(404);
+    reply.code(404)
     reply.send({
       error: 'Page not found'
     })
   })
-  done();
+  done()
 }
 
-module.exports = catchAllApi;
+module.exports = catchAllApi

--- a/src/routes/catch-all/catch-all-api-404.js
+++ b/src/routes/catch-all/catch-all-api-404.js
@@ -1,0 +1,11 @@
+const catchAllApi = function (fastify, options, done) {
+  fastify.get('*', (request, reply) => {
+    reply.code(404);
+    reply.send({
+      error: 'Page not found'
+    })
+  })
+  done();
+}
+
+module.exports = catchAllApi;

--- a/src/routes/catch-all/catch-all.js
+++ b/src/routes/catch-all/catch-all.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const catchAll = function (fastify, options, done) {
+  fastify.get('*', (request, reply) => {
+    const stream = fs.createReadStream(path.join(__dirname, '..', '..', '..', 'frontend', 'dist', 'index.html'));
+    reply.type('text/html').send(stream)
+  })
+  done();
+}
+
+module.exports = catchAll;

--- a/src/routes/catch-all/catch-all.js
+++ b/src/routes/catch-all/catch-all.js
@@ -1,12 +1,12 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs')
+const path = require('path')
 
 const catchAll = function (fastify, options, done) {
   fastify.get('*', (request, reply) => {
-    const stream = fs.createReadStream(path.join(__dirname, '..', '..', '..', 'frontend', 'dist', 'index.html'));
+    const stream = fs.createReadStream(path.join(__dirname, '..', '..', '..', 'frontend', 'dist', 'index.html'))
     reply.type('text/html').send(stream)
   })
-  done();
+  done()
 }
 
-module.exports = catchAll;
+module.exports = catchAll

--- a/tests-server/catch-all-api-404.spec.js
+++ b/tests-server/catch-all-api-404.spec.js
@@ -1,0 +1,26 @@
+/* globals beforeAll, afterAll, describe, test, expect */
+
+const app = require('./../src/app.js')
+
+describe('/api/*', () => {
+  let instance
+  beforeAll(async () => {
+    instance = await app({ port: 3000 }).ready()
+  })
+
+  afterAll(async () => {
+    instance.stop()
+  })
+
+  describe('GET not handled /api/ endpoint', () => {
+    test('should return status code 404 and error message "Page not found"', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/api/thisdoesntexist'
+      })
+
+      expect(result.statusCode).toBe(404)
+      expect(JSON.parse(result.payload).error).toEqual('Page not found')
+    })
+  })
+})

--- a/tests-server/catch-all.spec.js
+++ b/tests-server/catch-all.spec.js
@@ -1,0 +1,25 @@
+/* globals beforeAll, afterAll, describe, test, expect */
+
+const app = require('../src/app.js')
+
+describe('/*', () => {
+  let instance
+  beforeAll(async () => {
+    instance = await app({ port: 3000 }).ready()
+  })
+
+  afterAll(async () => {
+    instance.stop()
+  })
+
+  describe('GET any url not starting with /api/', () => {
+    test('should not return status code 404', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/authors'
+      })
+
+      expect(result.statusCode).not.toBe(404)
+    })
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   entry: './frontend/src/index.jsx',
   output: {
     filename: 'main.js',
-    path: path.resolve(__dirname, 'frontend/dist')
+    path: path.resolve(__dirname, 'frontend/dist'),
+    publicPath: '/'
   },
   module: {
     rules: [


### PR DESCRIPTION
As of this commit, URLs have to be typed in manualy in the browser. Routes other than `/authors` and `/authors/:id` will redirect to `/`. `/authors` and `/authors/:id` pages have temporary page content. 

Routes starting with `/api` will return a 404 error, unless a route starting with `/api` is handled.