### PR TITLE
feat: [PATRON2020-136] add cookies authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 frontend/dist
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -5386,6 +5386,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+    },
     "drange": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
@@ -5561,6 +5566,15 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
       "dev": true
+    },
+    "env-schema": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/env-schema/-/env-schema-1.1.0.tgz",
+      "integrity": "sha512-7tA+o0HdGtD5CZGLiN3dPO1OAu6qUaspY2gEmwbRTQ0yWst6Ov2svEdW8Y/30I4md8sRLX41p0vPp4RknmFsjg==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "dotenv": "^7.0.0"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -6571,6 +6585,32 @@
             "ipaddr.js": "1.9.1"
           }
         }
+      }
+    },
+    "fastify-cookie": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/fastify-cookie/-/fastify-cookie-3.6.0.tgz",
+      "integrity": "sha512-pvGzhtBIHP3NG/EWpf7WGzMjY+ur31uJ7XA2tz7iMpbl+T43pUM8WtDVMVoDAH1AJ3RAvSdVk58vZiqO4jUVfA==",
+      "requires": {
+        "cookie": "^0.4.0",
+        "cookie-signature": "^1.1.0",
+        "fastify-plugin": "^1.4.0"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
+          "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
+        }
+      }
+    },
+    "fastify-env": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-env/-/fastify-env-1.0.1.tgz",
+      "integrity": "sha512-984CVCWvMj1DwakDQ9mbKai2BOnG3i+4q6kGhn/8aTK4iPvcg5Yf9jOP2++Fv4K8DgSndgq28k+gehx47C0jqA==",
+      "requires": {
+        "env-schema": "^1.0.0",
+        "fastify-plugin": "^1.0.1"
       }
     },
     "fastify-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,6 +3621,11 @@
       "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
       "dev": true
     },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -9327,6 +9332,11 @@
         "package-json": "^4.0.0"
       }
     },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -10164,6 +10174,17 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "mocked-env": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mocked-env/-/mocked-env-1.3.2.tgz",
+      "integrity": "sha512-jwm3ziowCjpbLNhUNYwn2G0tawV/ZGRuWeEGt6PItrkQT74Nk3pDldL2pmwm9sQZw6a/x+ZBGeBVYq54acTauQ==",
+      "requires": {
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "lazy-ass": "1.6.0",
+        "ramda": "0.26.1"
       }
     },
     "move-concurrently": {
@@ -11729,6 +11750,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
       "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randexp": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fastify-swagger": "^2.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "mocked-env": "^1.3.2",
     "react-particles-js": "^2.7.1",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@testing-library/react": "^9.5.0",
     "axios": "^0.19.2",
     "fastify": "^2.13.0",
+    "fastify-cookie": "^3.6.0",
+    "fastify-env": "^1.0.1",
     "fastify-swagger": "^2.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,9 @@ module.exports = function ({ port }) {
   const app = require('fastify')({ logger: true })
   const serveStatic = require('serve-static')
 
+  app.register(require('./plugins/env'))
+  app.register(require('./plugins/cookies-authentication'))
+
   app.use('/', serveStatic(path.join(__dirname, '..', 'frontend', 'dist')))
 
   app

--- a/src/plugins/cookies-authentication/index.js
+++ b/src/plugins/cookies-authentication/index.js
@@ -1,0 +1,23 @@
+const fp = require('fastify-plugin')
+
+module.exports = fp(function (fastify, options, next) {
+  fastify.register(require('fastify-cookie'), {
+    parseOptions: {}
+  })
+
+  fastify.addHook('onRequest', (request, reply, done) => {
+    const serverSecret = fastify.config.COOKIE_SECRET
+    if (serverSecret !== '') {
+      const requestSecret = request.cookies.secret
+      if (serverSecret !== requestSecret) {
+        reply.code(401)
+        reply.send({
+          error: 'Unauthorized Error'
+        })
+      }
+    }
+    done()
+  })
+
+  next()
+})

--- a/src/plugins/cookies-authentication/index.js
+++ b/src/plugins/cookies-authentication/index.js
@@ -10,8 +10,7 @@ module.exports = fp(function (fastify, options, next) {
     if (serverSecret !== '') {
       const requestSecret = request.cookies.secret
       if (serverSecret !== requestSecret) {
-        reply.code(401)
-        reply.send({
+        reply.code(401).send({
           error: 'Unauthorized Error'
         })
       }

--- a/src/plugins/env/index.js
+++ b/src/plugins/env/index.js
@@ -26,8 +26,6 @@ module.exports = fp(function (fastify, options, next) {
     .register(fastifyEnv, envOptions)
     .ready((err) => {
       if (err) console.error(err)
-
-      console.log(fastify.config)
     })
 
   next()

--- a/src/plugins/env/index.js
+++ b/src/plugins/env/index.js
@@ -1,0 +1,34 @@
+const fastifyEnv = require('fastify-env')
+const fp = require('fastify-plugin')
+
+module.exports = fp(function (fastify, options, next) {
+  const schema = {
+    type: 'object',
+    required: ['COOKIE_SECRET'],
+    properties: {
+      COOKIE_SECRET: {
+        type: 'string',
+        default: ''
+      }
+    }
+  }
+
+  const envOptions = {
+    confKey: 'config',
+    schema: schema,
+    dotenv: {
+      path: './.env',
+      debug: true
+    }
+  }
+
+  fastify
+    .register(fastifyEnv, envOptions)
+    .ready((err) => {
+      if (err) console.error(err)
+
+      console.log(fastify.config)
+    })
+
+  next()
+})

--- a/tests-server/cookies-authentication.spec.js
+++ b/tests-server/cookies-authentication.spec.js
@@ -1,0 +1,73 @@
+/* globals beforeAll, afterAll, describe, test, expect, afterEach */
+const app = require('../src/app.js')
+
+describe('Cookie authentication', () => {
+  let instance
+
+  beforeAll(async () => {
+    instance = await app({ port: 3000 }).ready()
+  })
+
+  afterAll(async () => {
+    instance.stop()
+  })
+
+  describe('COOKIE_SECRET is defined in environment variables', () => {
+    beforeAll(async () => {
+      instance.config.COOKIE_SECRET = 'abcdef'
+    })
+    test('Should return 401 when request has no cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/'
+      })
+      expect(result.statusCode).toBe(401)
+    })
+
+    test('Should return 200 when request has correct cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/',
+        cookies: {
+          secret: 'abcdef'
+        }
+      })
+      expect(result.statusCode).toBe(200)
+    })
+
+    test('Should return 401 when request has incorrect cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/',
+        cookies: {
+          secret: 'fedcba'
+        }
+      })
+      expect(result.statusCode).toBe(401)
+    })
+  })
+
+  describe('COOKIE_SECRET is not defined in environment variables', () => {
+    beforeAll(async () => {
+      instance.config.COOKIE_SECRET = ''
+    })
+    test('Should return 200 when request has no cookie', async () => {
+      console.log(instance.config.COOKIE_SECRET)
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/'
+      })
+      expect(result.statusCode).toBe(200)
+    })
+    test('Should return 200 when request has cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/',
+        cookies: {
+          secret: 'abcdef'
+        }
+      })
+      expect(result.statusCode).toBe(200)
+    })
+  })
+})

--- a/tests-server/env.spec.js
+++ b/tests-server/env.spec.js
@@ -1,0 +1,39 @@
+/* globals beforeAll, afterAll, describe, test, expect, afterEach */
+const mockedEnv = require('mocked-env')
+const app = require('../src/app.js')
+
+describe('Environment variables', () => {
+  let instance
+  let restore
+  beforeAll(async () => {
+    instance = await app({ port: 3000 }).ready()
+    restore = mockedEnv({
+      COOKIE_SECRET: undefined
+    })
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  afterAll(async () => {
+    instance.stop()
+    restore()
+  })
+
+  describe('COOKIE_SECRET', () => {
+    test('should set fastify.config.COOKIE_SECRET to empty string when COOKIE_SECRET environment variable do not exists', async () => {
+      instance = await app({ port: 3000 }).ready()
+      expect(instance.config.COOKIE_SECRET).toBe('')
+    })
+
+    test('should set fastify.config.COOKIE_SECRET when COOKIE_SECRET environment variable exists', async () => {
+      restore = mockedEnv({
+        COOKIE_SECRET: 'abcdef'
+      })
+
+      instance = await app({ port: 3000 }).ready()
+      expect(instance.config.COOKIE_SECRET).toBe('abcdef')
+    })
+  })
+})


### PR DESCRIPTION

Load env variables from `.env` file in root folder. Secret is declared as

```
COOKIE_SECRET=XXX
```

Where `XXX` is secret.

If there's no `.env` file or there's no secret declared then everyone is allowed to access web application. 

Otherwise, when secret is declared in `.env`, secret is compared with cookie from request. Cookie name must be `secret`. If secret from `.env` is equal to secret from cookie then user is allowed to access website.

## Dev notes

For quick adding cookie, paste this in browser console:

```
var doSetCookie = function setCookie (c_name, value, exdays) {
  var exdate = new Date()
  exdate.setDate(exdate.getDate() + exdays)
  var c_value = escape(value) + ((exdays == null) ? '' : '; expires=' + exdate.toUTCString())
  document.cookie = c_name + '=' + c_value
}
doSetCookie('secret', '3241231213fsdj23kj4kl32j4', 1)
```

