### PR TITLE
fix: [PATRON2020-213] load authentication cookie name from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [fastify](https://www.fastify.io/)
 * [fastify-swagger](https://github.com/fastify/fastify-swagger)
 
+
 ## Testing setup
 
 * [Jest](https://jestjs.io/)
@@ -35,3 +36,29 @@ with any example provided in the `./src/docs/examples/` directory.
 1. Follow the `positive_example` example.
   1. Go to `openapi.json` and set what's needed.
   1. Go to `./src/docs/examples` and create what's needed.
+
+## Setting environment variables
+
+When deploying app in local environment create `.env` file in root directory which contains:
+
+```
+GATEWAY_URL='https://patronage20-concept-master.herokuapp.com'
+COOKIE_NAME=secret_cookie
+COOKIE_VALUE=3241231213fsdj23kj4kl32j4
+```
+
+`COOKIE_NAME` and `COOKIE_VALUE` are optional and should be both defined when cookie authentication is desirable.
+
+### Setting cookie in browser
+
+To set cookie in browser, paste following code into browser console. It is required when `COOKIE_NAME` and `COOKIE_VALUE` are defined in environment variables.
+
+```
+var doSetCookie = function setCookie (c_name, value, exdays) {
+  var exdate = new Date()
+  exdate.setDate(exdate.getDate() + exdays)
+  var c_value = escape(value) + ((exdays == null) ? '' : '; expires=' + exdate.toUTCString())
+  document.cookie = c_name + '=' + c_value + '; samesite=Lax'
+}
+doSetCookie('secret_cookie', '3241231213fsdj23kj4kl32j4', 1)
+```

--- a/src/plugins/cookies-authentication/index.js
+++ b/src/plugins/cookies-authentication/index.js
@@ -6,10 +6,12 @@ module.exports = fp(function (fastify, options, next) {
   })
 
   fastify.addHook('onRequest', (request, reply, done) => {
-    const serverSecret = fastify.config.COOKIE_SECRET
-    if (serverSecret !== '') {
-      const requestSecret = request.cookies.secret
-      if (serverSecret !== requestSecret) {
+    const cookieName = fastify.config.COOKIE_NAME
+    const cookieSecret = fastify.config.COOKIE_VALUE
+
+    if (cookieName && cookieSecret) {
+      const requestSecret = request.cookies[cookieName]
+      if (cookieSecret !== requestSecret) {
         reply.code(401).send({
           error: 'Unauthorized Error'
         })

--- a/src/plugins/env/index.js
+++ b/src/plugins/env/index.js
@@ -4,9 +4,13 @@ const fp = require('fastify-plugin')
 module.exports = fp(function (fastify, options, next) {
   const schema = {
     type: 'object',
-    required: ['COOKIE_SECRET', 'GATEWAY_URL'],
+    required: ['COOKIE_NAME', 'COOKIE_VALUE', 'GATEWAY_URL'],
     properties: {
-      COOKIE_SECRET: {
+      COOKIE_NAME: {
+        type: 'string',
+        default: ''
+      },
+      COOKIE_VALUE: {
         type: 'string',
         default: ''
       },

--- a/src/public/authors.json
+++ b/src/public/authors.json
@@ -3,7 +3,7 @@
     "id": 1,
     "name": "Marta",
     "github": "https://github.com/MartaJaszewska",
-    "avatar": "http://bit.ly/334tOSf"
+    "avatar": "https://avatars0.githubusercontent.com/u/55947981?s=400&u=0eb148e038d7154fdc23d8882f416667638c75f0&v=4"
   },
   {
     "id": 2,

--- a/tests-server/cookies-authentication.spec.js
+++ b/tests-server/cookies-authentication.spec.js
@@ -12,9 +12,10 @@ describe('Cookie authentication', () => {
     instance.stop()
   })
 
-  describe('COOKIE_SECRET is defined in environment variables', () => {
+  describe('COOKIE_NAME and COOKIE_VALUE are defined in environment variables', () => {
     beforeAll(async () => {
-      instance.config.COOKIE_SECRET = 'abcdef'
+      instance.config.COOKIE_VALUE = 'abcdef'
+      instance.config.COOKIE_NAME = 'secret'
     })
     test('Should return 401 when request has no cookie', async () => {
       const result = await instance.inject({
@@ -47,9 +48,60 @@ describe('Cookie authentication', () => {
     })
   })
 
-  describe('COOKIE_SECRET is not defined in environment variables', () => {
+  describe('COOKIE_VALUE and COOKIE_NAME are not defined in environment variables', () => {
     beforeAll(async () => {
-      instance.config.COOKIE_SECRET = ''
+      instance.config.COOKIE_VALUE = ''
+      instance.config.COOKIE_NAME = ''
+    })
+    test('Should return 200 when request has no cookie', async () => {
+      console.log(instance.config.COOKIE_SECRET)
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/'
+      })
+      expect(result.statusCode).toBe(200)
+    })
+    test('Should return 200 when request has cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/',
+        cookies: {
+          secret: 'abcdef'
+        }
+      })
+      expect(result.statusCode).toBe(200)
+    })
+  })
+
+  describe('COOKIE_VALUE is defined and COOKIE_NAME is not defined in environment variables', () => {
+    beforeAll(async () => {
+      instance.config.COOKIE_VALUE = 'abcdef'
+      instance.config.COOKIE_NAME = ''
+    })
+    test('Should return 200 when request has no cookie', async () => {
+      console.log(instance.config.COOKIE_SECRET)
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/'
+      })
+      expect(result.statusCode).toBe(200)
+    })
+    test('Should return 200 when request has cookie', async () => {
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/',
+        cookies: {
+          secret: 'abcdef'
+        }
+      })
+      expect(result.statusCode).toBe(200)
+    })
+  })
+
+  describe('COOKIE_VALUE is not defined and COOKIE_NAME is defined in environment variables', () => {
+    beforeAll(async () => {
+      instance.config.COOKIE_VALUE = ''
+      instance.config.COOKIE_NAME = 'secret'
     })
     test('Should return 200 when request has no cookie', async () => {
       console.log(instance.config.COOKIE_SECRET)

--- a/tests-server/env.spec.js
+++ b/tests-server/env.spec.js
@@ -21,19 +21,35 @@ describe('Environment variables', () => {
     restore()
   })
 
-  describe('COOKIE_SECRET', () => {
-    test('should set fastify.config.COOKIE_SECRET to empty string when COOKIE_SECRET environment variable do not exists', async () => {
+  describe('COOKIE_VALUE', () => {
+    test('should set fastify.config.COOKIE_VALUE to empty string when COOKIE_VALUE environment variable do not exists', async () => {
       instance = await app({ port: 3000 }).ready()
-      expect(instance.config.COOKIE_SECRET).toBe('')
+      expect(instance.config.COOKIE_VALUE).toBe('')
     })
 
-    test('should set fastify.config.COOKIE_SECRET when COOKIE_SECRET environment variable exists', async () => {
+    test('should set fastify.config.COOKIE_VALUE when COOKIE_VALUE environment variable exists', async () => {
       restore = mockedEnv({
-        COOKIE_SECRET: 'abcdef'
+        COOKIE_VALUE: 'abcdef'
       })
 
       instance = await app({ port: 3000 }).ready()
-      expect(instance.config.COOKIE_SECRET).toBe('abcdef')
+      expect(instance.config.COOKIE_VALUE).toBe('abcdef')
+    })
+  })
+
+  describe('COOKIE_NAME', () => {
+    test('should set fastify.config.COOKIE_NAME to empty string when COOKIE_NAME environment variable do not exists', async () => {
+      instance = await app({ port: 3000 }).ready()
+      expect(instance.config.COOKIE_NAME).toBe('')
+    })
+
+    test('should set fastify.config.COOKIE_NAME when COOKIE_NAME environment variable exists', async () => {
+      restore = mockedEnv({
+        COOKIE_NAME: 'secret'
+      })
+
+      instance = await app({ port: 3000 }).ready()
+      expect(instance.config.COOKIE_NAME).toBe('secret')
     })
   })
 })


### PR DESCRIPTION
Create `.env` file which contains:

```
COOKIE_NAME=secret_cookie
COOKIE_VALUE=3241231213fsdj23kj4kl32j4
GATEWAY_URL='https://patronage20-concept-master.herokuapp.com'
```

Add cookie to browser with this javascript:

```
var doSetCookie = function setCookie (c_name, value, exdays) {
  var exdate = new Date()
  exdate.setDate(exdate.getDate() + exdays)
  var c_value = escape(value) + ((exdays == null) ? '' : '; expires=' + exdate.toUTCString())
  document.cookie = c_name + '=' + c_value + '; samesite=Strict'
}
doSetCookie('secret_cookie', '3241231213fsdj23kj4kl32j4', 1)
```

