### PR TITLE
feat: PATRON2020-137 add gateway connection check

### DIFF
--- a/frontend/src/components/UI/Snackbars/ConnectionWarningSnackbar/WarningSnackbar.jsx
+++ b/frontend/src/components/UI/Snackbars/ConnectionWarningSnackbar/WarningSnackbar.jsx
@@ -7,6 +7,7 @@ const WarningSnackbar = ({ pingEndpoint }) => {
   const { t } = useTranslation()
 
   let key
+  const status = [408, 502, 504]
 
   const handleSnackbarEnqueueing = () => {
     if (!key) {
@@ -26,7 +27,7 @@ const WarningSnackbar = ({ pingEndpoint }) => {
   }
 
   const showSnackbar = (error) => {
-    !error.response || error.response.status === 408
+    !error.response || status.includes(error.response.status)
       ? handleSnackbarEnqueueing()
       : console.error(error)
   }
@@ -43,7 +44,6 @@ const WarningSnackbar = ({ pingEndpoint }) => {
 
   let interval
   useEffect(() => {
-    // clearInterval(interval)
     checkConnection()
     interval = setInterval(() => checkConnection(), 10000)
     return () => {

--- a/frontend/src/components/UI/Snackbars/ConnectionWarningSnackbar/WarningSnackbar.test.js
+++ b/frontend/src/components/UI/Snackbars/ConnectionWarningSnackbar/WarningSnackbar.test.js
@@ -80,6 +80,42 @@ describe.only('WarningSnackbar component', () => {
     expect(callMock).toHaveBeenCalledTimes(2)
   })
 
+  it('should open the snackbar when the HTTP code is 502', async () => {
+    const callMock = jest.fn()
+      .mockReturnValueOnce([200, {}])
+      .mockReturnValueOnce([502, {}])
+      .mockName('serverEndpoint')
+    axiosMock
+      .onGet('/health-check')
+      .reply(callMock)
+    const { getByText } = render(
+      <SnackbarProvider>
+        <WarningSnackbar pingEndpoint={pingEndpointMock} />
+      </SnackbarProvider>
+    )
+    jest.advanceTimersByTime(11000)
+    await waitForElement(() => getByText('Hey, something isn\'t quite right! Check your connection.'))
+    expect(callMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('should open the snackbar when the HTTP code is 504', async () => {
+    const callMock = jest.fn()
+      .mockReturnValueOnce([200, {}])
+      .mockReturnValueOnce([504, {}])
+      .mockName('serverEndpoint')
+    axiosMock
+      .onGet('/health-check')
+      .reply(callMock)
+    const { getByText } = render(
+      <SnackbarProvider>
+        <WarningSnackbar pingEndpoint={pingEndpointMock} />
+      </SnackbarProvider>
+    )
+    jest.advanceTimersByTime(11000)
+    await waitForElement(() => getByText('Hey, something isn\'t quite right! Check your connection.'))
+    expect(callMock).toHaveBeenCalledTimes(2)
+  })
+
   it('should open the snackbar when there is a network error', async () => {
     isOnlineGetter.mockReturnValue(false)
     axiosMock.onGet('/health-check')
@@ -89,5 +125,6 @@ describe.only('WarningSnackbar component', () => {
       </SnackbarProvider>
     )
     await waitForElement(() => getByText('Hey, something isn\'t quite right! Check your connection.'))
+    expect(getByText('Hey, something isn\'t quite right! Check your connection.')).not.toEqual(null)
   })
 })

--- a/frontend/src/views/Layout.jsx
+++ b/frontend/src/views/Layout.jsx
@@ -5,7 +5,7 @@ import WarningSnackbar from '../components/UI/Snackbars/ConnectionWarningSnackba
 import axios from 'axios'
 import CustomSnackbarProvider from '../components/UI/Snackbars/CustomSnackbarProvider'
 
-const pingEndpoint = () => axios.get('/.well-known/health-check', { timeout: 5000 })
+const pingApiEndpoint = () => axios.get('/.well-known/health-check', { timeout: 5000 })
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -23,7 +23,7 @@ const Layout = ({ children }) => {
   return (
     <Grid container maxwidth='xs' className={classes.root} data-testid='dashboard-id'>
       <CustomSnackbarProvider>
-        <WarningSnackbar pingEndpoint={pingEndpoint} />
+        <WarningSnackbar pingEndpoint={pingApiEndpoint} />
         <Navigation />
         <Grid container maxwidth='xs' className={classes.content}>
           {children}

--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,9 @@ module.exports = function ({ port }) {
           instance.swagger()
         })
 
-      instance.register(require('./routes/well-known/health-check'))
+      instance.register(require('./routes/well-known/health-check'), {
+        GATEWAY_URL: app.config.GATEWAY_URL
+      })
 
       next()
     },

--- a/src/routes/well-known/health-check.js
+++ b/src/routes/well-known/health-check.js
@@ -1,9 +1,24 @@
+const axios = require('axios')
+
 module.exports = function (instance, opts, next) {
   instance.get('/health-check', async (request, reply) => {
-    reply.send({
-      message: 'OK'
-    })
-  })
+    let payload = { message: 'OK' }
+    const gatewayUrl = opts.GATEWAY_URL
 
+    const timeout = setTimeout(() => {
+      reply.code(504)
+      payload = { error: '504 Gateway Timeout' }
+    }, 4000)
+
+    await axios.get(`${gatewayUrl}/notifications`)
+      .then(() => { clearTimeout(timeout) })
+      .catch(() => {
+        clearTimeout(timeout)
+        reply.code(502)
+        payload = { error: '502 Bad Gateway' }
+      })
+
+    reply.send(payload)
+  })
   next()
 }

--- a/tests-server/health-check.spec.js
+++ b/tests-server/health-check.spec.js
@@ -1,6 +1,9 @@
 /* globals beforeEach, afterEach, describe, test, expect */
 const mockedEnv = require('mocked-env')
 const app = require('./../src/app.js')
+const axios = require('axios')
+
+jest.mock('axios')
 
 // Start application before running the test case
 describe('/.well-known/health-check', function () {
@@ -22,7 +25,9 @@ describe('/.well-known/health-check', function () {
   })
 
   describe('GET method', () => {
-    test('should return status code 200 and OK', async function () {
+    test('should return status code 200 and message "OK" on successful response from gateway', async function () {
+      axios.get.mockImplementation(() => Promise.resolve({ status: 200, data: {} }))
+
       const result = await instance.inject({
         method: 'GET',
         url: '/.well-known/health-check'
@@ -31,6 +36,41 @@ describe('/.well-known/health-check', function () {
       expect(result.statusCode).toBe(200)
       expect(JSON.parse(result.payload)).toEqual({
         message: 'OK'
+      })
+    })
+
+    test('should return status code 504 and error "504 Gateway Timeout" on gateway timeout', async function () {
+      jest.useFakeTimers()
+      axios.get.mockImplementation(() => {
+        jest.advanceTimersByTime(4050)
+        return Promise.resolve()
+      })
+
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/.well-known/health-check'
+      })
+
+      expect(result.statusCode).toBe(504)
+      expect(JSON.parse(result.payload)).toEqual({
+        error: '504 Gateway Timeout'
+      })
+
+      jest.clearAllTimers()
+      jest.useRealTimers()
+    })
+
+    test('should return status code 502 and error "502 Bad Gateway" on gateway bad response', async function () {
+      axios.get.mockImplementation(() => Promise.reject(new Error('err')))
+
+      const result = await instance.inject({
+        method: 'GET',
+        url: '/.well-known/health-check'
+      })
+
+      expect(result.statusCode).toBe(502)
+      expect(JSON.parse(result.payload)).toEqual({
+        error: '502 Bad Gateway'
       })
     })
   })


### PR DESCRIPTION
Added endpoint for checking API's connection with Gateway. In case of a timeout (5 seconds) 504 status code is returned. If gateway's response isn't 200, 502 is returned from the endpoint. 