### PR TITLE
fix: PATRON2020-263 fix snackbars not reacting to language change

### DIFF
--- a/frontend/src/components/Navigation/NavigationBar/Header/tests/Header.test.js
+++ b/frontend/src/components/Navigation/NavigationBar/Header/tests/Header.test.js
@@ -6,6 +6,11 @@ import { MemoryRouter } from 'react-router-dom'
 import configureStore from 'redux-mock-store'
 import Header from '../Header.jsx'
 import i18n from '../../../../../i18n'
+import { SnackbarProvider } from 'notistack'
+
+jest.mock('notistack', () => ({
+  ...jest.requireActual('notistack')
+}))
 
 const mockStore = configureStore([])
 
@@ -55,31 +60,45 @@ describe('<Header />', () => {
         isDrawerOpen: false
       }
     }
+    jest.clearAllMocks()
   })
 
   it('renders header component', () => {
+    const notistack = require('notistack')
+
+    const closeSnackbar = jest.fn()
+    jest.spyOn(notistack, 'useSnackbar').mockImplementation(() => { return { closeSnackbar } })
+
     const { queryByTestId } = render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={initialRoute}>
-          <I18nextProvider i18n={i18n}>
-            <Header />
-          </I18nextProvider>
-        </MemoryRouter>
+        <SnackbarProvider>
+          <MemoryRouter initialEntries={initialRoute}>
+            <I18nextProvider i18n={i18n}>
+              <Header />
+            </I18nextProvider>
+          </MemoryRouter>
+        </SnackbarProvider>
       </Provider>
     )
     expect(queryByTestId('header-id')).toBeTruthy()
   })
 
   it('checks if the dashboard is in the tabs', () => {
+    const notistack = require('notistack')
+
+    const closeSnackbar = jest.fn()
+    jest.spyOn(notistack, 'useSnackbar').mockImplementation(() => { return { closeSnackbar } })
+
     const { queryByTestId } = render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={initialRoute}>
-          <I18nextProvider i18n={i18n}>
-            <Header />
-          </I18nextProvider>
-        </MemoryRouter>
+        <SnackbarProvider>
+          <MemoryRouter initialEntries={initialRoute}>
+            <I18nextProvider i18n={i18n}>
+              <Header />
+            </I18nextProvider>
+          </MemoryRouter>
+        </SnackbarProvider>
       </Provider>
-
     )
     expect(queryByTestId('dashboard-tab-id')).toBeTruthy()
   })

--- a/frontend/src/components/UI/LanguageSelect/LanguageSelect.jsx
+++ b/frontend/src/components/UI/LanguageSelect/LanguageSelect.jsx
@@ -4,6 +4,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import FormControl from '@material-ui/core/FormControl'
 import Select from '@material-ui/core/Select'
 
+import { useSnackbar } from 'notistack'
 import { useTranslation } from 'react-i18next'
 
 const useStyles = makeStyles((theme) => ({
@@ -24,13 +25,16 @@ const useStyles = makeStyles((theme) => ({
 
 export default function LanguageSelect () {
   const { i18n } = useTranslation()
+  const { closeSnackbar } = useSnackbar()
 
   const [language, setLanguage] = React.useState(i18n.language)
 
   const changeLanguage = lang => {
+    if (lang === language) { return }
     window.localStorage.setItem('language', lang)
     i18n.changeLanguage(lang)
     setLanguage(lang)
+    closeSnackbar()
   }
 
   if (i18n.language !== 'en' && i18n.language !== 'pl') { // unknown language, fallback to en

--- a/frontend/src/components/UI/LanguageSelect/LanguageSelect.spec.js
+++ b/frontend/src/components/UI/LanguageSelect/LanguageSelect.spec.js
@@ -3,6 +3,11 @@ import { render, screen, fireEvent, waitForElement, cleanup } from '@testing-lib
 import LanguageSelect from './index'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../../i18n'
+import { SnackbarProvider } from 'notistack'
+
+jest.mock('notistack', () => ({
+  ...jest.requireActual('notistack')
+}))
 
 describe('<LanguageSelect />', () => {
   let mocki18n
@@ -19,18 +24,22 @@ describe('<LanguageSelect />', () => {
 
   it('renders LanguageSelect component', () => {
     const root = render(
-      <I18nextProvider i18n={mocki18n}>
-        <LanguageSelect />
-      </I18nextProvider>
+      <SnackbarProvider>
+        <I18nextProvider i18n={mocki18n}>
+          <LanguageSelect />
+        </I18nextProvider>
+      </SnackbarProvider>
     )
     expect(root).not.toBeNull()
   })
 
   it('changes i18n.language on language change', async () => {
     render(
-      <I18nextProvider i18n={mocki18n}>
-        <LanguageSelect />
-      </I18nextProvider>
+      <SnackbarProvider>
+        <I18nextProvider i18n={mocki18n}>
+          <LanguageSelect />
+        </I18nextProvider>
+      </SnackbarProvider>
     )
 
     const languageMenu = screen.getByRole('button')
@@ -56,9 +65,11 @@ describe('<LanguageSelect />', () => {
     })
 
     render(
-      <I18nextProvider i18n={mocki18n}>
-        <LanguageSelect />
-      </I18nextProvider>
+      <SnackbarProvider>
+        <I18nextProvider i18n={mocki18n}>
+          <LanguageSelect />
+        </I18nextProvider>
+      </SnackbarProvider>
     )
 
     const languageMenu = screen.getByRole('button')
@@ -85,9 +96,11 @@ describe('<LanguageSelect />', () => {
 
     mocki18n.changeLanguage('pl')
     render(
-      <I18nextProvider i18n={mocki18n}>
-        <LanguageSelect />
-      </I18nextProvider>
+      <SnackbarProvider>
+        <I18nextProvider i18n={mocki18n}>
+          <LanguageSelect />
+        </I18nextProvider>
+      </SnackbarProvider>
     )
 
     const languageMenu = screen.getByRole('button')

--- a/frontend/src/components/UI/Snackbars/SensorsWarning/SensorsWarning.jsx
+++ b/frontend/src/components/UI/Snackbars/SensorsWarning/SensorsWarning.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useSnackbar } from 'notistack'
 import { useTranslation } from 'react-i18next'
@@ -8,18 +8,15 @@ export default function SensorsWarning () {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
   const refreshError = useSelector((state) => state.sensor.refreshError)
 
-  const [key, setKey] = useState(null)
-
   useEffect(() => {
-    if (refreshError && !key) {
-      setKey(enqueueSnackbar(t('dashboard:sensors-refresh-error'), {
+    if (refreshError) {
+      enqueueSnackbar(t('dashboard:sensors-refresh-error'), {
         variant: 'warning',
         persist: true,
-        onExiting: () => setKey(null)
-      }))
-    } else if (!refreshError && key) {
-      closeSnackbar(key)
-      setKey(null)
+        key: 'sensors-refresh-error-snackbar'
+      })
+    } else if (!refreshError) {
+      closeSnackbar('sensors-refresh-error-snackbar')
     }
   }, [refreshError])
 

--- a/frontend/src/components/UI/Snackbars/SensorsWarning/SensorsWarning.spec.js
+++ b/frontend/src/components/UI/Snackbars/SensorsWarning/SensorsWarning.spec.js
@@ -53,41 +53,12 @@ describe('<SensorsWarning />', () => {
     expect(screen.getByText('Could not refresh sensors\' status.')).not.toEqual(null)
   })
 
-  it('should not show a new snackbar if one is already open', () => {
-    const notistack = require('notistack')
-
-    const enqueueSnackbar = jest.fn()
-    jest.spyOn(notistack, 'useSnackbar').mockImplementation(() => { return { enqueueSnackbar } })
-
-    const setKey = jest.fn()
-    const useStateMock = () => ['testKey', setKey]
-    jest.spyOn(React, 'useState').mockImplementation(useStateMock)
-
-    const initialState = { sensor: { refreshError: 'error' } }
-    const mockStore = configureStore()
-    const store = mockStore(initialState)
-
-    render(
-      <Provider store={store}>
-        <SnackbarProvider>
-          <SensorsWarning />
-        </SnackbarProvider>
-      </Provider>
-    )
-
-    expect(enqueueSnackbar).toHaveBeenCalledTimes(0)
-    expect(setKey).toHaveBeenCalledTimes(0)
-  })
-
-  it('should close a snackbar if snackbar is open and refreshError is set to null', () => {
+  it('should close a snackbar if snackbar is open and refreshError is set to null, should not open a new one', () => {
     const notistack = require('notistack')
 
     const closeSnackbar = jest.fn()
-    jest.spyOn(notistack, 'useSnackbar').mockImplementation(() => { return { closeSnackbar } })
-
-    const setKey = jest.fn()
-    const useStateMock = () => ['testKey', setKey]
-    jest.spyOn(React, 'useState').mockImplementation(useStateMock)
+    const enqueueSnackbar = jest.fn()
+    jest.spyOn(notistack, 'useSnackbar').mockImplementation(() => { return { enqueueSnackbar, closeSnackbar } })
 
     const initialState = { sensor: { refreshError: null } }
     const mockStore = configureStore()
@@ -102,6 +73,6 @@ describe('<SensorsWarning />', () => {
     )
 
     expect(closeSnackbar).toHaveBeenCalledTimes(1)
-    expect(setKey).toHaveBeenCalledTimes(1)
+    expect(enqueueSnackbar).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/data/reducers/sensor.js
+++ b/frontend/src/data/reducers/sensor.js
@@ -28,7 +28,8 @@ const fetchSensorsSuccess = (state, action) => {
   return {
     ...state,
     sensors,
-    loadingSensors: false
+    loadingSensors: false,
+    refreshError: null
   }
 }
 

--- a/frontend/src/data/reducers/tests/sensor.spec.js
+++ b/frontend/src/data/reducers/tests/sensor.spec.js
@@ -74,7 +74,8 @@ describe('sensor reducer', () => {
     expect(reducer(initialState, actions.fetchSensorsSuccess(testSensors))).toEqual({
       ...initialState,
       sensors: testSensors,
-      loadingSensors: false
+      loadingSensors: false,
+      refreshError: null
     })
   })
 


### PR DESCRIPTION
Fixed bug reported by Antoni Morwiński (https://tracker.intive.com/jira/browse/PATRON2020-263). 

Snackbars now hide on language change. If they are triggered again, they reappear with a message in a proper language. 

Also fixed other minor bug I noticed, related to sensors' refresh error snackbar not closing when switching tabs and going back to dashboard. Now this snackbar is properly updated whenever dashboard is rendered. 