### PR TITLE
fix: PATRON2020-192 inconsistent background colors

### DIFF
--- a/frontend/src/components/Dashboard/SensorsList/SensorsList.jsx
+++ b/frontend/src/components/Dashboard/SensorsList/SensorsList.jsx
@@ -22,7 +22,8 @@ const useStyles = makeStyles((theme) => ({
     height: props.sidebarHeight + 'px',
     backgroundColor: theme.palette.background.level2
   }),
-  list: {
+  listSubheader: {
+    backgroundColor: theme.palette.background.level2
   }
 }))
 
@@ -120,14 +121,14 @@ export default function SensorsList () {
       <List
         className={classes.list}
         data-testid='not-connected-sensors-list'
-        subheader={<ListSubheader>{t('dashboard:sensors-not-placed')}</ListSubheader>}
+        subheader={<ListSubheader className={classes.listSubheader}>{t('dashboard:sensors-not-placed')}</ListSubheader>}
       >
         {drawItems(notConnectedSensors, false, setActiveModal, expanded, handleChangeExpanded)}
       </List>
       <List
         className={classes.list}
         data-testid='connected-sensors-list'
-        subheader={<ListSubheader>{t('dashboard:sensors-placed')}</ListSubheader>}
+        subheader={<ListSubheader className={classes.listSubheader}>{t('dashboard:sensors-placed')}</ListSubheader>}
       >
         {drawItems(connectedSensors, true, setActiveModal, expanded, handleChangeExpanded)}
       </List>

--- a/frontend/src/views/Layout.jsx
+++ b/frontend/src/views/Layout.jsx
@@ -12,8 +12,9 @@ const useStyles = makeStyles(theme => ({
     height: '100vh'
   },
   content: {
-    height: 'calc(100vh - 65px)', // check navigation height in frontend\src\components\Navigation\Navigation.jsx if needed
-    boxSizing: 'border-box'
+    height: 'calc(100vh - 64px)', // check navigation height in frontend\src\components\Navigation\Navigation.jsx if needed
+    boxSizing: 'border-box',
+    backgroundColor: theme.palette.background.default
   }
 }))
 


### PR DESCRIPTION
# UI fixes - bug PATRON2020-313

[Link to task in Jira.](https://tracker.intive.com/jira/browse/PATRON2020-313)

- Fixed inconsistent background colors. Before the fix, only the map had background color the same as specified in theme.pallete.
- Fixed notification icon size in the header. This fix removed the scrollbar on the dashboard.
- Fixed transparent subheaders in the sensors list. Before the fix, subheaders were not properly displayed when the sensor list was scrolled.

Before:
![image](https://user-images.githubusercontent.com/3882385/80961656-b0c97a80-8e0b-11ea-9a8b-c6a6befa5204.png)

After:
![image](https://user-images.githubusercontent.com/3882385/80961677-bb840f80-8e0b-11ea-86f0-db2f8a5dfe94.png)
