### PR TITLE
fix: PATRON2020-412 fix light border not displaying in HSV format

### DIFF
--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/Sensor.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/Sensor.jsx
@@ -77,7 +77,27 @@ const Sensor = (props) => {
     return innerSensorComponent[sensorType]
   }
 
-  const getLightColor = () => `hsl(${sensorData.hue}, ${sensorData.saturation}%, ${sensorData.value}%)`
+  const convertHsvToHsl = (h, s, v) => {
+    const l = (2 - s / 100) * v / 2
+
+    if (l !== 0) {
+      if (l === 100) {
+        s = 0
+      } else if (l < 50) {
+        s = s * v / (l * 2)
+      } else {
+        s = s * v / (200 - l * 2)
+      }
+    }
+
+    return [h, s, l]
+  }
+
+  const getLightColor = () => {
+    const hsl = convertHsvToHsl(sensorData.hue, sensorData.saturation, sensorData.value)
+
+    return `hsl(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%)`
+  }
 
   const isLightSensor = type === 'LED_CONTROLLER'
   const sensorBorderColor = isLightSensor ? getLightColor() : sensorColor


### PR DESCRIPTION
Light sensors' borders now properly display in HSV format