### PR TITLE
fix: PATRON2020-341 fix adding sensors on map on extreme left and top positions

### DIFF
--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { useDispatch, useSelector } from 'react-redux'
-
 import sensorsInfo from '@constants/sensorsInfo'
 import { onMapClick } from '@data/actions/mapListCommunicationActions.js'
 import house from '@assets/house.svg'
@@ -134,13 +133,13 @@ const HomeMap = () => {
     }
 
     const { offsetX = 0, offsetY = 0 } = e.nativeEvent
+
     /** Offset defined in map's width in percent. */
-    const xCoordinate = fromCoordinateToPercentMapper(
-      offsetX - Math.floor((mapHeight / (SENSOR_COEFFICIENT * SENSOR_COEFFICIENT))), mapWidth)
+    const xCoordinate = fromCoordinateToPercentMapper(offsetX, mapWidth)
     /** Offset defined in map's height in percent. */
-    const yCoordinate = fromCoordinateToPercentMapper(
-      offsetY - Math.floor((mapHeight / (SENSOR_COEFFICIENT * SENSOR_COEFFICIENT))), mapHeight)
+    const yCoordinate = fromCoordinateToPercentMapper(offsetY, mapHeight)
     /** Sensors fetched from store and mapper to appropriate format. */
+
     const storeSensors = sensors
       .map((sensor) => Object.assign(sensor, { x: sensor.mapPosition.x, y: sensor.mapPosition.y }))
 
@@ -197,8 +196,8 @@ const HomeMap = () => {
                   { width: Math.round(mapHeight / SENSOR_COEFFICIENT), height: Math.round(mapHeight / SENSOR_COEFFICIENT) }
                 }
                 position={{
-                  top: fromPercentToCoordinateMapper(point.mapPosition.y, mapHeight) - mapHeight / SENSOR_COEFFICIENT / 2,
-                  left: fromPercentToCoordinateMapper(point.mapPosition.x, mapWidth) - mapWidth / SENSOR_COEFFICIENT / 2,
+                  top: fromPercentToCoordinateMapper(point.mapPosition.y, mapHeight) - Math.round(mapHeight / SENSOR_COEFFICIENT) / 2,
+                  left: fromPercentToCoordinateMapper(point.mapPosition.x, mapWidth) - Math.round(mapHeight / SENSOR_COEFFICIENT) / 2,
                   position: 'absolute'
                 }}
                 sensorColor={'black' && sensorsInfo[point.type] && sensorsInfo[point.type].color}

--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
@@ -25,8 +25,7 @@ const SENSOR_COEFFICIENT = 20
 const useStyles = makeStyles((props) => ({
   container: {
     position: 'relative',
-    overflow: 'hidden',
-    top: '20px'
+    overflow: 'hidden'
   },
   image: props => ({
     cursor: props.mapDisabled
@@ -35,7 +34,7 @@ const useStyles = makeStyles((props) => ({
     height: 'auto',
     width: 'auto',
     minWidth: '100%',
-    maxHeight: 'calc(100vh - 250px)'
+    maxHeight: 'calc(100vh - 150px)'
   })
 }))
 
@@ -137,10 +136,10 @@ const HomeMap = () => {
     const { offsetX = 0, offsetY = 0 } = e.nativeEvent
     /** Offset defined in map's width in percent. */
     const xCoordinate = fromCoordinateToPercentMapper(
-      offsetX - (mapHeight / SENSOR_COEFFICIENT / 2), mapWidth)
+      offsetX - Math.floor((mapHeight / (SENSOR_COEFFICIENT * SENSOR_COEFFICIENT))), mapWidth)
     /** Offset defined in map's height in percent. */
     const yCoordinate = fromCoordinateToPercentMapper(
-      offsetY - (mapHeight / SENSOR_COEFFICIENT / 2), mapHeight)
+      offsetY - Math.floor((mapHeight / (SENSOR_COEFFICIENT * SENSOR_COEFFICIENT))), mapHeight)
     /** Sensors fetched from store and mapper to appropriate format. */
     const storeSensors = sensors
       .map((sensor) => Object.assign(sensor, { x: sensor.mapPosition.x, y: sensor.mapPosition.y }))
@@ -198,8 +197,8 @@ const HomeMap = () => {
                   { width: Math.round(mapHeight / SENSOR_COEFFICIENT), height: Math.round(mapHeight / SENSOR_COEFFICIENT) }
                 }
                 position={{
-                  top: fromPercentToCoordinateMapper(point.mapPosition.y, mapHeight),
-                  left: fromPercentToCoordinateMapper(point.mapPosition.x, mapWidth),
+                  top: fromPercentToCoordinateMapper(point.mapPosition.y, mapHeight) - mapHeight / SENSOR_COEFFICIENT / 2,
+                  left: fromPercentToCoordinateMapper(point.mapPosition.x, mapWidth) - mapWidth / SENSOR_COEFFICIENT / 2,
                   position: 'absolute'
                 }}
                 sensorColor={'black' && sensorsInfo[point.type] && sensorsInfo[point.type].color}

--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/Sensor.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/Sensor.jsx
@@ -87,8 +87,8 @@ const Sensor = (props) => {
     sensorBorderColor: sensorBorderColor,
     clicked: clicked,
     sensorSize: sensorSize,
-    width: '20px' && sensorSize && sensorSize.width,
-    height: '20px' && sensorSize && sensorSize.height,
+    width: sensorSize.width || '20px',
+    height: sensorSize.height || '20px',
     position: position,
     borderSize: isLightSensor ? 4 : 2
   })

--- a/frontend/src/components/Dashboard/SmartHomeMap/SmartHomeMap.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/SmartHomeMap.jsx
@@ -7,6 +7,8 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.background.default
   },
   mapContainer: {
+    display: 'flex',
+    alignItems: 'center',
     maxWidth: '100%',
     height: 'calc(100vh - 64px)',
     objectFit: 'contain'


### PR DESCRIPTION
User can now add sensor points on slightly left and top positions, before percentage value for these positions equals less than 0, now it is fixed and all map positions are between 0 and 100. I try to fix drawing sensor points perfectly in the middle of the clicked point on the map, but I'm not sure about x axis. I think it slightly moved to the left. If someone has an idea how to improve it, I would be grateful for the help 