### PR TITLE
fix: PATRON2020-395 blinds slider position update

### DIFF
--- a/frontend/src/components/Dashboard/SensorsList/ItemDetails/WindowBlindsItemDetails.js
+++ b/frontend/src/components/Dashboard/SensorsList/ItemDetails/WindowBlindsItemDetails.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import Typography from '@material-ui/core/Typography'
 import Slider from '@material-ui/core/Slider'
 import Button from '@material-ui/core/Button'
@@ -22,6 +22,10 @@ export default function WindowBlindsItemDetails ({ sensorData, handleChangeExpan
   const classes = useStyles()
 
   const [position, setPosition] = useState(sensorData.position)
+
+  useEffect(() => {
+    setPosition(sensorData.position)
+  }, [sensorData])
 
   const dispatchWindowBlindsDetailsChange = () => {
     const windowBlindsDetails = {


### PR DESCRIPTION
This PR fixes bug with blinds slider. Position slider was not updated when change was made from other source (for example from another tab or from mobile application). This fix made component update slider position on every change in sensor data. 
