### PR TITLE
fix: PATRON2020-429 fix window blinds icon not displaying properly

### DIFF
--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/InnerSensorComponents/WindowBlindsSensorInner.js
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Sensor/InnerSensorComponents/WindowBlindsSensorInner.js
@@ -24,11 +24,11 @@ const useStyles = makeStyles((props) => ({
 
 export default function WindowBlindsSensorInner ({ position }) {
   const getBlindPositionToDisplay = (position) => {
-    if (position > 87) return 100
-    else if (position > 62) return 75
+    if (position > 87) return 0
+    else if (position > 62) return 25
     else if (position > 37) return 50
-    else if (position > 12) return 25
-    else if (position >= 0) return 0
+    else if (position > 12) return 75
+    else if (position >= 0) return 100
   }
 
   const classes = useStyles({ position: getBlindPositionToDisplay(position) })


### PR DESCRIPTION
Window blinds icon now properly displays the real bilnds position