### PR TITLE
fix: hide sensors lists headers when lists are empty

### DIFF
--- a/frontend/src/components/Dashboard/SensorsList/SensorsList.jsx
+++ b/frontend/src/components/Dashboard/SensorsList/SensorsList.jsx
@@ -15,6 +15,7 @@ import { useSnackbar } from 'notistack'
 
 import { dbRemovePoint, dbUpdateRemoveErrorPoints } from '@data/actions/dbActions.js'
 import { onMapClick } from '@data/actions/mapListCommunicationActions.js'
+import { divideSensors, isSensorsListEmpty } from './helpers'
 
 const useStyles = makeStyles((theme) => ({
   root: props => ({
@@ -44,17 +45,6 @@ function drawItems (sensors, isOnMap, handleRemoveClick, expanded, handleChangeE
       )
     }))
   }))
-}
-
-const divideSensors = (sensors) => {
-  const connectedSensors = {}
-  const notConnectedSensors = {}
-  for (const key in sensors) {
-    connectedSensors[key] = sensors[key].filter(sensor => sensor.mapPosition !== undefined)
-    notConnectedSensors[key] = sensors[key].filter(sensor => sensor.mapPosition === undefined)
-  }
-
-  return { connectedSensors, notConnectedSensors }
 }
 
 export default function SensorsList () {
@@ -122,14 +112,28 @@ export default function SensorsList () {
       <List
         className={classes.list}
         data-testid='not-connected-sensors-list'
-        subheader={<ListSubheader disableSticky>{t('dashboard:sensors-not-placed')}</ListSubheader>}
+        subheader={!isSensorsListEmpty(notConnectedSensors) &&
+          <ListSubheader
+            disableSticky
+            className={classes.listSubheader}
+            data-testid='notConnected-header'
+          >
+            {t('dashboard:sensors-not-placed')}
+          </ListSubheader>}
       >
         {drawItems(notConnectedSensors, false, setActiveModal, expanded, handleChangeExpanded)}
       </List>
       <List
         className={classes.list}
         data-testid='connected-sensors-list'
-        subheader={<ListSubheader disableSticky>{t('dashboard:sensors-placed')}</ListSubheader>}
+        subheader={!isSensorsListEmpty(connectedSensors) &&
+          <ListSubheader
+            disableSticky
+            className={classes.listSubheader}
+            data-testid='connected-header'
+          >
+            {t('dashboard:sensors-placed')}
+          </ListSubheader>}
       >
         {drawItems(connectedSensors, true, setActiveModal, expanded, handleChangeExpanded)}
       </List>

--- a/frontend/src/components/Dashboard/SensorsList/__tests__/SensorsList.spec.js
+++ b/frontend/src/components/Dashboard/SensorsList/__tests__/SensorsList.spec.js
@@ -128,4 +128,89 @@ describe('<SensorsList />', () => {
     // 1 sensor + header = 2 children
     expect(queryByTestId('not-connected-sensors-list').childElementCount).toBe(2)
   })
+
+  test('should render lists headers when sensorsLists have elements', () => {
+    store = mockStore({
+      sensor: {
+        sensors: {
+          temperatureSensors: [
+            {
+              id: 1,
+              type: 'TEMPERATURE_SENSOR',
+              value: 21
+            },
+            {
+              id: 9,
+              type: 'TEMPERATURE_SENSOR',
+              value: 22,
+              mapPosition: {
+                x: 0,
+                y: 0
+              }
+            },
+            {
+              id: 10,
+              type: 'TEMPERATURE_SENSOR',
+              value: 22,
+              mapPosition: {
+                x: 0,
+                y: 0
+              }
+            }]
+        }
+      },
+      mapListCommunication: {
+        pressedItemId: 3
+      },
+      dbInteraction: {
+        _id: 1,
+        removeError: false,
+        removeErrorPoints: []
+      },
+      loadingSensors: false
+    })
+
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <SnackbarProvider>
+          <SensorsList />
+        </SnackbarProvider>
+      </Provider>
+
+    )
+    expect(queryByTestId('sensors-list')).toBeTruthy()
+    expect(queryByTestId('notConnected-header')).toBeTruthy()
+    expect(queryByTestId('connected-header')).toBeTruthy()
+  })
+
+  test('should not render lists headers when sensorsLists are empty', () => {
+    store = mockStore({
+      sensor: {
+        sensors: {
+          temperatureSensors: []
+        }
+      },
+      mapListCommunication: {
+        pressedItemId: 3
+      },
+      dbInteraction: {
+        _id: 1,
+        removeError: false,
+        removeErrorPoints: []
+      },
+      loadingSensors: false
+    })
+
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <SnackbarProvider>
+          <SensorsList />
+        </SnackbarProvider>
+      </Provider>
+
+    )
+    expect(queryByTestId('sensors-list')).toBeTruthy()
+    expect(queryByTestId('notConnected-header')).toBeFalsy()
+    expect(queryByTestId('connected-header')).toBeFalsy()
+  })
 })

--- a/frontend/src/components/Dashboard/SensorsList/__tests__/helpers.spec.js
+++ b/frontend/src/components/Dashboard/SensorsList/__tests__/helpers.spec.js
@@ -1,0 +1,89 @@
+import { divideSensors, isSensorsListEmpty } from '../helpers'
+
+describe('Sensors list helper functions test', () => {
+  describe('divideSensors', () => {
+    test('should divide sensors list into objects with lists', () => {
+      const mockSensors = {
+        temperatureSensors: [
+          {
+            id: 1,
+            type: 'TEMPERATURE_SENSOR',
+            value: 21
+          },
+          {
+            id: 10,
+            type: 'TEMPERATURE_SENSOR',
+            value: 22,
+            mapPosition: {
+              x: 77,
+              y: 56
+            }
+          }
+        ],
+        windowSensors: [
+          {
+            id: 2,
+            type: 'windowSensor',
+            status: 'open'
+          }
+        ],
+        lights: [
+          {
+            id: 6,
+            type: 'LED_CONTROLLER',
+            hue: 17,
+            saturation: 40,
+            value: 32
+          }
+        ]
+      }
+
+      const { connectedSensors, notConnectedSensors } = divideSensors(mockSensors)
+      let connectedSensorsLength = 0
+      for (const key in connectedSensors) {
+        connectedSensorsLength += connectedSensors[key].length
+      }
+      expect(connectedSensorsLength).toBe(1)
+
+      let notConnectedSensorsLength = 0
+      for (const key in notConnectedSensors) {
+        notConnectedSensorsLength += notConnectedSensors[key].length
+      }
+      expect(notConnectedSensorsLength).toBe(3)
+    })
+  })
+
+  describe('isSensorsListEmpty', () => {
+    test('should return true if sensorsList is empty', () => {
+      const mockSensors = {
+        temperatureSensors: [],
+        windowSensors: [],
+        windowBlinds: [],
+        RFIDSensors: [],
+        smokeSensors: [],
+        lights: []
+      }
+
+      expect(isSensorsListEmpty(mockSensors)).toBeTruthy()
+    })
+
+    test('should return false if sensorsList is not empty', () => {
+      const mockSensors = {
+        temperatureSensors: [],
+        windowSensors: [],
+        windowBlinds: [
+          {
+            id: 3,
+            type: 'windowBlind',
+            position: 90
+          }
+        ],
+        RFIDSensors: [],
+        smokeSensors: [],
+        lights: []
+      }
+
+      expect(isSensorsListEmpty(mockSensors)).toBeFalsy()
+    })
+  })
+})

--- a/frontend/src/components/Dashboard/SensorsList/helpers.js
+++ b/frontend/src/components/Dashboard/SensorsList/helpers.js
@@ -1,0 +1,24 @@
+const divideSensors = (sensors) => {
+  const connectedSensors = {}
+  const notConnectedSensors = {}
+  for (const key in sensors) {
+    connectedSensors[key] = sensors[key].filter(sensor => sensor.mapPosition !== undefined)
+    notConnectedSensors[key] = sensors[key].filter(sensor => sensor.mapPosition === undefined)
+  }
+
+  return { connectedSensors, notConnectedSensors }
+}
+
+const isSensorsListEmpty = (sensorsList) => {
+  for (const key in sensorsList) {
+    if (sensorsList[key] && sensorsList[key].length > 0) {
+      return false
+    }
+  }
+  return true
+}
+
+export {
+  divideSensors,
+  isSensorsListEmpty
+}


### PR DESCRIPTION
This PR hides sensor lists headers when list is empty.

Moved functions to `helpers.js` file. Added tests. 

Before:
![image](https://user-images.githubusercontent.com/3882385/83063133-fae6fa00-a05f-11ea-8d53-0d698b2a7f76.png)

After:
![image](https://user-images.githubusercontent.com/3882385/83063146-01757180-a060-11ea-91b0-a161c239a9d0.png)
