### PR TITLE
fix: PATRON2020-466 fix clicking on sensor list when item is highlighted

### DIFF
--- a/frontend/src/components/Dashboard/SensorsList/Item.jsx
+++ b/frontend/src/components/Dashboard/SensorsList/Item.jsx
@@ -13,7 +13,7 @@ import MuiExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
 import MuiExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 import SettingsIcon from '@material-ui/icons/Settings'
 
-import { onListClick } from '@data/actions/mapListCommunicationActions.js'
+import { onListClick, onMapClick } from '@data/actions/mapListCommunicationActions.js'
 import LightItemInfo from './ItemInfo/LightItemInfo'
 import RFIDSensorItemInfo from './ItemInfo/RFIDSensorItemInfo'
 import SmokeSensorItemInfo from './ItemInfo/SmokeSensorItemInfo'
@@ -194,7 +194,7 @@ const Item = ({ sensorData, isOnMap, handleRemoveClick, expanded, handleChangeEx
         >
           <ListItem
             id={`sensor${id}`}
-            onClick={(e) => { handleListItemClick(e) }}
+            onClick={(e) => { clicked ? dispatch(onMapClick()) : handleListItemClick(e) }}
           >
             <ListItemAvatar className={classes.icon}>
               {drawSensorGraphicComponent(type === 'TEMPERATURE_SENSOR' ? 'TEMPERATURE_SENSOR_ICON' : type, sensorData)}

--- a/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
+++ b/frontend/src/components/Dashboard/SmartHomeMap/Map/Map.jsx
@@ -28,8 +28,8 @@ const useStyles = makeStyles((props) => ({
   },
   image: props => ({
     cursor: props.mapDisabled
-      ? props.pointPressed ? 'pointer' : 'cell'
-      : 'not-allowed',
+      ? 'cell'
+      : props.pointPressed ? 'pointer' : 'not-allowed',
     height: 'auto',
     width: 'auto',
     minWidth: '100%',
@@ -69,11 +69,12 @@ const HomeMap = () => {
     return Object.keys(sensors).map(key => sensors[key]).flat().filter(sensor => sensor.mapPosition)
   })
 
+  const checkListSensorClicked = () => sensors.filter(s => s.id === mapListCommunication.pressedItemId).length === 1
+
   const classes = useStyles({
     mapDisabled:
-      mapListCommunication.waitingForSensorLocation ||
-      mapListCommunication.mapPointPressed,
-    pointPressed: mapListCommunication.mapPointPressed
+      mapListCommunication.waitingForSensorLocation,
+    pointPressed: mapListCommunication.mapPointPressed || checkListSensorClicked()
   })
 
   useEffect(() => {
@@ -125,7 +126,7 @@ const HomeMap = () => {
   * @param e Mouse click event.
   */
   const addNewSensor = (e) => {
-    if (mapListCommunication.mapPointPressed) {
+    if (mapListCommunication.mapPointPressed || checkListSensorClicked()) {
       dispatch(onMapClick())
     }
     if (!mapListCommunication.waitingForSensorLocation) {

--- a/frontend/src/components/UI/NotificationDrawer/NotificationDrawerList.jsx
+++ b/frontend/src/components/UI/NotificationDrawer/NotificationDrawerList.jsx
@@ -16,6 +16,9 @@ const NotificationDrawerList = ({ notifications, handleNotificationCheck, sensor
   const sensor = notification => sensors.find(sensor => sensor.id === notification.sensorId) || ''
 
   const [clicked, setClicked] = useState(null)
+  const handleClick = (id) => {
+    setClicked(clicked === id ? null : id)
+  }
 
   return (
     <div role='presentation' data-testid='notification-list'>
@@ -27,7 +30,7 @@ const NotificationDrawerList = ({ notifications, handleNotificationCheck, sensor
             handleNotificationCheck={handleNotificationCheck}
             sensor={sensor(notification)}
             clicked={clicked === notification.id}
-            handleClick={() => setClicked(notification.id)}
+            handleClick={() => handleClick(notification.id)}
           />
         ))}
       </List>


### PR DESCRIPTION
Now items from the sensor list can be unclicked in two ways. 

1. First is just clicking on the item from the list
2. Second way lets the user to:
    a) click on the sensor item on the list which is placed on the map and click anywhere on the map to unclicked item
    b) click on the sensor point on the map and click anywhere on the map to unclicked the chosen point