### PR TITLE
fix: PATRON2020-409 fix tab highlight after change site to notifications

### DIFF
--- a/frontend/src/components/Navigation/NavigationBar/Header/Header.jsx
+++ b/frontend/src/components/Navigation/NavigationBar/Header/Header.jsx
@@ -59,7 +59,7 @@ function checkActive (url) {
     '/hvac': 1,
     '/authors': 2
   }
-  return sites[url] || 0
+  return sites[url]
 }
 
 export default function Header () {


### PR DESCRIPTION
Before when changing the site to '/notifications' tab with Dashboard was highlighted even if we were before on HVAC or Authors site. Now changing the site to '/notifications' causes that neither of the tabs is highlighted