### PR TITLE
fix: PATRON2020-398 update lights sliders positions on state change

### DIFF
--- a/frontend/src/components/Dashboard/SensorsList/ItemDetails/LightItemDetails.js
+++ b/frontend/src/components/Dashboard/SensorsList/ItemDetails/LightItemDetails.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import Typography from '@material-ui/core/Typography'
 import Slider from '@material-ui/core/Slider'
 import Button from '@material-ui/core/Button'
@@ -68,7 +68,21 @@ export default function LightItemInfo ({ sensorData, handleChangeExpanded }) {
   const [hue, setHue] = useState(sensorData.hue)
   const [saturation, setSaturation] = useState(sensorData.saturation)
   const [value, setValue] = useState(sensorData.value)
+  const [originalSensorData, setOriginalSensorData] = useState(sensorData)
   const classes = useStyles({ hue, saturation, value })
+
+  useEffect(() => {
+    const hasSensorDataChanged = sensorData.hue !== originalSensorData.hue ||
+        sensorData.value !== originalSensorData.value ||
+        sensorData.saturation !== originalSensorData.saturation
+
+    if (hasSensorDataChanged) {
+      setHue(sensorData.hue)
+      setSaturation(sensorData.saturation)
+      setValue(sensorData.value)
+      setOriginalSensorData(sensorData)
+    }
+  })
 
   const dispatchLightDetailsChange = () => {
     const lightSensorDetails = {

--- a/frontend/src/components/Dashboard/SensorsList/ItemDetails/WindowBlindsItemDetails.js
+++ b/frontend/src/components/Dashboard/SensorsList/ItemDetails/WindowBlindsItemDetails.js
@@ -22,10 +22,15 @@ export default function WindowBlindsItemDetails ({ sensorData, handleChangeExpan
   const classes = useStyles()
 
   const [position, setPosition] = useState(sensorData.position)
+  const [originalSensorData, setOriginalSensorData] = useState(sensorData)
 
   useEffect(() => {
-    setPosition(sensorData.position)
-  }, [sensorData])
+    const hasSensorDataChanged = originalSensorData.position !== sensorData.position
+    if (hasSensorDataChanged) {
+      setPosition(sensorData.position)
+      setOriginalSensorData(sensorData)
+    }
+  })
 
   const dispatchWindowBlindsDetailsChange = () => {
     const windowBlindsDetails = {


### PR DESCRIPTION
~~This PR is yet to be tested. Currently, the gateway is not working and I don't know any option to test this fix.~~

***

**Why did I've added new state in components?**

This `const [originalSensorData, setOriginalSensorData] = useState(sensorData)` state is for tracking if sensorData has changed in the store. 
It prevents updating sliders while new data has not yet been submitted.

Let's consider these following examples:

1. User A is setting hue for the led lamp. In the same time application fetch data from the backend, but the sensor data is the same as before. Slider position should not change to starting position, because it would be a bad user experience. *(This bug is presented on following animation)*
2. User A is setting hue for the led lamp. Meanwhile, User B changed value of the same lamp. Application fetches new data from the backend. Sensor data differs from `originalSensorData`. Slider position is updated.

These two situations are correctly handled by this fix. 

![97Ya2Wu6ME](https://user-images.githubusercontent.com/3882385/83640734-d84b6880-a5ac-11ea-9f4c-fa4e63b123be.gif)

